### PR TITLE
Points speechbrain dependency to upstream development branch instead of PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
 # retico-speechbraintts
-
 Local speechbrain speech synthesis for retico.
 
 ## Installation and requirements
-
-You can install the module via pip:
-
+You can install the package with the following command:
 ```bash
-$ pip install retico-speechbraintts
-```
-
-For this, PyTorch has to be installed:
-
-```bash
-$ pip install torch
+pip install git+https://github.com/retico-team/retico-speechbraintts
 ```
 
 ## Example
-
 ```python
-from retico_core import *
-import retico_wav2vecasr
-import retico_speechbraintts
+from retico_core.debug import DebugModule
+from retico_core.audio import MicrophoneModule, SpeakerModule
+from retico_googleasr import GoogleASRModule
+from retico_speechbraintts import SpeechBrainTTSModule
 
-microphone = audio.MicrophoneModule()
-asr = retico_wav2vecasr.Wav2VecASRModule("en")
-tts = retico_speechbraintts.SpeechBrainTTSModule("en")
-speaker = audio.SpeakerModule(rate=22050)
 
-microphone.subscribe(asr)
+debug = DebugModule(print_payload_only=True)
+mic = MicrophoneModule()
+asr = GoogleASRModule(rate=16_000)
+tts = SpeechBrainTTSModule("en")
+speaker = SpeakerModule(rate=22050)
+
+mic.subscribe(asr)
 asr.subscribe(tts)
+asr.subscribe(debug)
 tts.subscribe(speaker)
 
-network.run(asr)
+mic.run()
+asr.run()
+tts.run()
+speaker.run()
+debug.run()
 
-print("Running the TTS. Press enter to exit")
 input()
 
-network.stop(asr)
+mic.stop()
+asr.stop()
+tts.stop()
+speaker.stop()
+debug.stop()
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ dynamic = ["version"]
 dependencies = [
     "numpy",
     "retico-core>=2.0.0",
-    "speechbrain<=1.0.3",
+    # this is a temporary stop-gap until speechbrain releases an updated PyPI package
+    #    "speechbrain",
+    "speechbrain @ git+https://github.com/speechbrain/speechbrain.git",
+    # speechbrain hasn't yet updated for torch>=2.9
     "torch<2.9",
 ]
 authors = [

--- a/retico_speechbraintts/speechbraintts.py
+++ b/retico_speechbraintts/speechbraintts.py
@@ -1,12 +1,10 @@
-from email.mime import audio
 import os
 import threading
 import time
 from hashlib import blake2b
-
 import retico_core
-from speechbrain.pretrained import Tacotron2
-from speechbrain.pretrained import HIFIGAN
+from speechbrain.inference import Tacotron2
+from speechbrain.inference import HIFIGAN
 import numpy as np
 
 


### PR DESCRIPTION
HuggingFace made some breaking changes a few months ago which aren't accounted for in the latest speechbrain release. This PR temporarily changes pyproject.toml to point to the speechbrain development branch, which has implemented fixes for this problem, until an updated speechbrain package is published to PyPI.

Closes #1